### PR TITLE
Internal Roll Commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,14 +53,14 @@ dependencies = [
 
 [[package]]
 name = "async-tls"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce6977f57fa68da77ffe5542950d47e9c23d65f5bc7cb0a9f8700996913eec7"
+checksum = "d7e7fbc0843fc5ad3d5ca889c5b2bea9130984d34cd0e62db57ab70c2529a8e3"
 dependencies = [
  "futures",
- "rustls 0.16.0",
+ "rustls 0.18.1",
  "webpki",
- "webpki-roots 0.17.0",
+ "webpki-roots 0.20.0",
 ]
 
 [[package]]
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.4.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4187bb446c8ecb8849f17cef7553db8bdb09e482e806257130189958fb42dca7"
+checksum = "a5c45a0dd44b7e6533ac4e7acc38ead1a3b39885f5bbb738140d30ea528abc7c"
 dependencies = [
  "async-tls",
  "futures-io",
@@ -131,15 +131,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -158,23 +149,11 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
  "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -182,12 +161,6 @@ name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecount"
@@ -277,10 +250,9 @@ dependencies = [
 
 [[package]]
 name = "command_attr"
-version = "0.2.0"
-source = "git+https://github.com/acdenisSK/serenity.git?branch=await_next#3b53fd356d52ecb0e985a5199e4ce56a568166e3"
+version = "0.3.0-rc.0"
+source = "git+https://github.com/serenity-rs/serenity?branch=current#59fb7b9cc7d62270c45528aca9d20ac36ca95b4d"
 dependencies = [
- "futures",
  "proc-macro2",
  "quote",
  "syn",
@@ -301,6 +273,12 @@ name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crc32fast"
@@ -379,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
 ]
@@ -435,12 +413,6 @@ dependencies = [
  "backtrace",
  "version_check",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fehler"
@@ -627,11 +599,12 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -983,7 +956,7 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 [[package]]
 name = "mice"
 version = "0.8.0"
-source = "git+https://github.com/Monadic-Cat/mice?branch=rework#425355c63a72b83b8bfee815a2eb6e043fc4a05b"
+source = "git+https://github.com/Monadic-Cat/mice?branch=rework#5294530b4eaa95f684cf66519834f6d07b959294"
 dependencies = [
  "nom",
  "rand 0.7.3",
@@ -1200,9 +1173,9 @@ checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -1562,11 +1535,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
+checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.11.0",
  "log",
  "ring",
  "sct",
@@ -1575,11 +1548,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.12.3",
  "log",
  "ring",
  "sct",
@@ -1723,10 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.8.6"
-source = "git+https://github.com/acdenisSK/serenity.git?branch=await_next#3b53fd356d52ecb0e985a5199e4ce56a568166e3"
+version = "0.9.0-rc.0"
+source = "git+https://github.com/serenity-rs/serenity?branch=current#59fb7b9cc7d62270c45528aca9d20ac36ca95b4d"
 dependencies = [
- "async-tls",
  "async-trait",
  "async-tungstenite",
  "base64 0.12.3",
@@ -1738,7 +1710,6 @@ dependencies = [
  "futures",
  "log",
  "reqwest",
- "rustls 0.17.0",
  "serde",
  "serde_json",
  "static_assertions 1.1.0",
@@ -1746,19 +1717,18 @@ dependencies = [
  "typemap_rev",
  "url",
  "uwl",
- "webpki",
- "webpki-roots 0.19.0",
 ]
 
 [[package]]
 name = "sha-1"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
  "block-buffer",
+ "cfg-if",
+ "cpuid-bool",
  "digest",
- "fake-simd",
  "opaque-debug",
 ]
 
@@ -2127,11 +2097,11 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "tungstenite"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.12.3",
  "byteorder",
  "bytes",
  "http",
@@ -2353,15 +2323,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a262ae37dd9d60f60dd473d1158f9fbebf110ba7b6a5051c8160460f6043718b"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
@@ -2371,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,13 @@ features = [ "runtime-tokio", "macros", "sqlite" ]
 optional = true
 
 [features]
-default = ["bot_commands", "cli_control"]
+default = ["bot_commands", "cli_control", "internal_rolls"]
 bot_commands = []
 # This feature is incomplete.
 turns_db = ["sqlx", "fehler", "comfy-table"]
 # This feature is incomplete.
 control_socket = []
+internal_rolls  = []
 
 # I believe some parts of the cli_control feature may violate
 # the Discord Terms of Service, so tread with care.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "AGPL-3.0-or-later"
 
 [dependencies]
-serenity = { git = "https://github.com/acdenisSK/serenity.git", branch = "await_next", features = ["framework", "standard_framework"] }
+serenity = { git = "https://github.com/serenity-rs/serenity", branch = "current", features = ["framework", "standard_framework"] }
 tokio = { version = "0.2", features = ["full"] }
 mice = { git = "https://github.com/Monadic-Cat/mice", branch = "rework" }
 nom = "5.0"

--- a/src/internal_rolls.rs
+++ b/src/internal_rolls.rs
@@ -1,0 +1,89 @@
+//! Parsing roll commands from normal messages,
+//! 
+//! in the form of "...normal text...(roll: <dice expression>)...normal text..."
+use ::core::num::NonZeroU8;
+use ::mice::parse::{dice, whitespace, Expression, InvalidDie};
+use ::nom::{bytes::complete::tag, multi::many0, sequence::tuple, IResult};
+
+fn internal_roll(input: &str) -> IResult<&str, Result<Expression, InvalidDie>> {
+    let (input, (_, _, res, _, _)) = tuple((
+        tag("(roll:"),
+        many0(whitespace),
+        dice,
+        many0(whitespace),
+        tag(")"),
+    ))(input)?;
+    Ok((input, res))
+}
+
+enum ParseState {
+    RollingEnabled,
+    RollingDisabled {
+        backticks: NonZeroU8,
+        block_quote: bool,
+    },
+}
+
+#[derive(Debug)]
+struct FoundRolls {
+    rolls: Vec<Result<Expression, InvalidDie>>,
+}
+impl FoundRolls {
+    fn new() -> Self {
+        Self { rolls: Vec::new() }
+    }
+    fn push(&mut self, val: Result<Expression, InvalidDie>) {
+        self.rolls.push(val)
+    }
+}
+#[derive(Debug)]
+pub(crate) struct ParsedMessage {
+    rolls: FoundRolls,
+}
+impl ParsedMessage {
+    fn new() -> Self {
+        Self {
+            rolls: FoundRolls::new(),
+        }
+    }
+}
+
+/// *All* messages are valid.
+///
+/// *Some* messages contain rolls for us to handle.
+///
+/// *Some* messages contain syntactically valid rolls that have no valid evaluation tactic.
+pub(crate) fn message(input: &str) -> ParsedMessage {
+    // Time to scroll across the thing uwu
+    let mut place = input;
+    let mut state = ParseState::RollingEnabled;
+    let mut info = ParsedMessage::new();
+    while place.len() > 1 {
+        match state {
+            ParseState::RollingEnabled => {
+                // Somewhere, we want to do our checks for moving to the RollingDisabled state.
+                match internal_roll(place) {
+                    // The current place is a valid internal roll command.
+                    // Store the parsed result of that, and scroll past.
+                    Ok((input, res)) => {
+                        info.rolls.push(res);
+                        place = input;
+                    }
+                    // The current place is not a syntactically valid internal roll command.
+                    // That does not make this message invalid.
+                    // Just move forward one step.
+                    // Note that this can panic by creating an invalid UTF-8 slice.
+                    // We should probably change the dice parsers,
+                    // which do not inherently require valid UTF-8 input.
+                    // That change would essentially be the replacement of
+                    // `&str` with `&[u8]` in a number of places.
+                    // It may also be useful to make an iterator
+                    // for the creation of shrinking slices across our input.
+                    Err(_) => place = &place[1..],
+                }
+            }
+            ParseState::RollingDisabled { .. } => {}
+        }
+    }
+    info
+}

--- a/src/internal_rolls.rs
+++ b/src/internal_rolls.rs
@@ -16,25 +16,13 @@ fn internal_roll(input: &str) -> IResult<&str, Result<Expression, InvalidDie>> {
 }
 
 #[derive(Debug)]
-struct FoundRolls {
-    rolls: Vec<Result<Expression, InvalidDie>>,
-}
-impl FoundRolls {
-    fn new() -> Self {
-        Self { rolls: Vec::new() }
-    }
-    fn push(&mut self, val: Result<Expression, InvalidDie>) {
-        self.rolls.push(val)
-    }
-}
-#[derive(Debug)]
 pub(crate) struct ParsedMessage {
-    rolls: FoundRolls,
+    rolls: Vec<Result<Expression, InvalidDie>>,
 }
 impl ParsedMessage {
     fn new() -> Self {
         Self {
-            rolls: FoundRolls::new(),
+            rolls: Vec::new(),
         }
     }
 }

--- a/src/internal_rolls.rs
+++ b/src/internal_rolls.rs
@@ -1,7 +1,6 @@
 //! Parsing roll commands from normal messages,
 //! 
-//! in the form of "...normal text...(roll: <dice expression>)...normal text..."
-use ::core::num::NonZeroU8;
+//! in the form of "...normal text...(roll: &lt;dice expression>)...normal text..."
 use ::mice::parse::{dice, whitespace, Expression, InvalidDie};
 use ::nom::{bytes::complete::tag, multi::many0, sequence::tuple, IResult};
 
@@ -14,14 +13,6 @@ fn internal_roll(input: &str) -> IResult<&str, Result<Expression, InvalidDie>> {
         tag(")"),
     ))(input)?;
     Ok((input, res))
-}
-
-enum ParseState {
-    RollingEnabled,
-    RollingDisabled {
-        backticks: NonZeroU8,
-        block_quote: bool,
-    },
 }
 
 #[derive(Debug)]
@@ -56,33 +47,30 @@ impl ParsedMessage {
 pub(crate) fn message(input: &str) -> ParsedMessage {
     // Time to scroll across the thing uwu
     let mut place = input;
-    let mut state = ParseState::RollingEnabled;
     let mut info = ParsedMessage::new();
     while place.len() > 1 {
-        match state {
-            ParseState::RollingEnabled => {
-                // Somewhere, we want to do our checks for moving to the RollingDisabled state.
-                match internal_roll(place) {
-                    // The current place is a valid internal roll command.
-                    // Store the parsed result of that, and scroll past.
-                    Ok((input, res)) => {
-                        info.rolls.push(res);
-                        place = input;
-                    }
-                    // The current place is not a syntactically valid internal roll command.
-                    // That does not make this message invalid.
-                    // Just move forward one step.
-                    // Note that this can panic by creating an invalid UTF-8 slice.
-                    // We should probably change the dice parsers,
-                    // which do not inherently require valid UTF-8 input.
-                    // That change would essentially be the replacement of
-                    // `&str` with `&[u8]` in a number of places.
-                    // It may also be useful to make an iterator
-                    // for the creation of shrinking slices across our input.
-                    Err(_) => place = &place[1..],
-                }
+        match internal_roll(place) {
+            // The current place is a valid internal roll command.
+            // Store the parsed result of that, and scroll past.
+            Ok((input, res)) => {
+                info.rolls.push(res);
+                place = input;
             }
-            ParseState::RollingDisabled { .. } => {}
+            // The current place is not a syntactically valid internal roll command.
+            // That does not make this message invalid.
+            // Just move forward one step.
+            // Note that this can panic by creating an invalid UTF-8 slice.
+            // We should probably change the dice parsers,
+            // which do not inherently require valid UTF-8 input.
+            // That change would essentially be the replacement of
+            // `&str` with `&[u8]` in a number of places.
+            // It may also be useful to make an iterator
+            // for the creation of shrinking slices across our input.
+            Err(::nom::Err::Failure((_, ::nom::error::ErrorKind::TooLarge))) => {
+                place = &place[1..];
+                info.rolls.push(Err(InvalidDie));
+            },
+            _ => place = &place[1..],
         }
     }
     info

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use mice::FormatOptions as MiceFormat;
 use ::mice::util::ExpressionExt;
 mod initiative;
 use initiative::pathfinder_initiative;
+#[cfg(feature = "internal_rolls")]
 mod internal_rolls;
 #[cfg(feature = "cli_control")]
 mod cmd;
@@ -619,37 +620,45 @@ impl EventHandler for Handler {
         #[cfg(feature = "control_socket")]
         control_socket::control_loop("/home/jmn/mbot.socket").await;
     }
-    // for turn tracking
-    #[cfg(feature = "turns_db")]
+    #[cfg(any(feature = "internal_rolls", feature = "turns_db"))]
     async fn message(&self, ctx: Context, msg: Message) {
-        let guild_id = msg.guild_id.unwrap().0 as i64;
-        match turns::attempt_turn(
-            msg.author.id.0 as i64,
-            msg.channel_id.0 as i64,
-            msg.timestamp.into(),
-        )
-        .await
-        {
-            Ok(_) => (),
-            Err(e @ turns::TurnError::NotInGame(_))
-            | Err(e @ turns::TurnError::NotInRound(_))
-            | Err(e @ turns::TurnError::WrongTurn(_)) => match e.notify_channel() {
-                Some(c) => match c
-                    .say(ctx.http, format!("{}: {}", msg.author.mention(), e))
-                    .await
-                {
-                    Ok(_) => (),
-                    Err(e2) => log::error!("{} AFTER {}", e2, e),
-                },
-                None => log::error!("{}", e),
-            },
-            // This isn't really an error.
-            // It's just someone posting in a channel we see that
-            // has no games associated with it.
-            // Therefore, do no response and no logging.
-            Err(turns::TurnError::NoGameHere) => (),
-            // TODO: suppress SQLx errors from when we don't find a server/game/channel
-            Err(turns::TurnError::SqlxError(e)) => log::error!("sqlx: {}", e),
+        #[cfg(feature = "internal_rolls")] {
+            match internal_rolls::response_for(&msg.content) {
+                Some(x) => { reply(&ctx, &msg, &format!("\n{}", x)).await; },
+                None => (),
+            }
+        }
+        // for turn tracking
+        #[cfg(feature = "turns_db")] {
+            let guild_id = msg.guild_id.unwrap().0 as i64;
+            match turns::attempt_turn(
+                msg.author.id.0 as i64,
+                msg.channel_id.0 as i64,
+                msg.timestamp.into(),
+            )
+                .await
+            {
+                Ok(_) => (),
+                Err(e @ turns::TurnError::NotInGame(_))
+                    | Err(e @ turns::TurnError::NotInRound(_))
+                    | Err(e @ turns::TurnError::WrongTurn(_)) => match e.notify_channel() {
+                        Some(c) => match c
+                            .say(ctx.http, format!("{}: {}", msg.author.mention(), e))
+                            .await
+                        {
+                            Ok(_) => (),
+                            Err(e2) => log::error!("{} AFTER {}", e2, e),
+                        },
+                        None => log::error!("{}", e),
+                    },
+                // This isn't really an error.
+                // It's just someone posting in a channel we see that
+                // has no games associated with it.
+                // Therefore, do no response and no logging.
+                Err(turns::TurnError::NoGameHere) => (),
+                // TODO: suppress SQLx errors from when we don't find a server/game/channel
+                Err(turns::TurnError::SqlxError(e)) => log::error!("sqlx: {}", e),
+            }
         }
     }
     // for turn tracking

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use mice::FormatOptions as MiceFormat;
 use ::mice::util::ExpressionExt;
 mod initiative;
 use initiative::pathfinder_initiative;
+mod internal_rolls;
 #[cfg(feature = "cli_control")]
 mod cmd;
 #[cfg(feature = "cli_control")]


### PR DESCRIPTION
It came to my attention today that RPBot, another dice rolling Discord bot,
provides the rolling of a single dice expression inside a non command prefixed message.
(As in, not in the form of `!roll d20`.)
For this form, one instead writes `(roll: d20)`, for example, somewhere inside their message text.

After a conversation on Discord, I've decided to implement this feature as well.
Unlike RPBot, however, I intend to support many dice rolls in a single message.